### PR TITLE
New live demo, fix BorderHighlight

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,109 +4,154 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-    <title>NiiVue</title>
+    <title>Drawing</title>
     <link rel="stylesheet" href="niivue.css" />
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
   </head>
   <body>
     <noscript>
       <strong>niivue requires JavaScript.</strong>
     </noscript>
     <header>
-      <label for="check1">LR</label>
-      <input type="checkbox" id="check1" unchecked />
-      <label for="check2">Nose</label>
-      <input type="checkbox" id="check2" unchecked />
-      <label for="check3">World</label>
-      <input type="checkbox" id="check3" unchecked />
-      <label for="dragMode">Drag mode</label>
-      <select id="dragMode">
-        <option value="contrast">contrast</option>
-        <option value="measurement">measurement</option>
-        <option value="pan" selected>pan/zoom</option>
-        <option value="slicer3D">slicer3D</option>
-        <option value="none">none</option>
+      <label for="drawPen">Draw color:</label>
+      <select name="drawPen" id="drawPen">
+        <option value="-1">Off</option>
+        <option value="0">Erase</option>
+        <option value="1">Red</option>
+        <option value="2">Green</option>
+        <option value="3">Blue</option>
+        <option value="8">Filled Erase</option>
+        <option value="9">Filled Red</option>
+        <option value="10">Filled Green</option>
+        <option value="11">Filled Blue</option>
+        <option value="12">Erase Selected Cluster</option>
       </select>
-      <button id="reset">reset</button>
+      <button id="left">left</button>
+      <button id="right">right</button>
+      <button id="posterior">posterior</button>
+      <button id="anterior">anterior</button>
+      <button id="inferior">inferior</button>
+      <button id="superior">superior</button>
+      <button id="info">info</button>
+      <button id="save">save drawing</button>
+      <button id="undo">undo</button>
+      <button id="growcut">grow cut</button>
+      <label for="drawOpacity">drawing opacity</label>
+      <input
+        type="range"
+        min="0"
+        max="100"
+        value="80"
+        class="slider"
+        id="drawOpacity"
+      />
+      <label for="check1">fill pen overwrites</label>
+      <input type="checkbox" id="check1" name="check1" checked />
+      <label for="check2">Radiological</label>
+      <input type="checkbox" id="check2" name="check2" unchecked />
+      <label for="check3">World space</label>
+      <input type="checkbox" id="check3" name="check3" unchecked />
+      <label for="check9">Linear Interpolation</label>
+      <input type="checkbox" id="check9" name="check9" checked />
+      <label for="check10">HighDPI</label>
+      <input type="checkbox" id="check10" name="check10" checked />
     </header>
-    <main>
+    <main id="container">
       <canvas id="gl1"></canvas>
     </main>
-    <footer id="location">&nbsp;</footer>
-    <script type="module" async>
+  </body>
+</html>
+<script type="module" async>
       import { Niivue } from "./niivue.js";
       import { NVImage } from "./nvimage.js";
       import { NVMesh } from "./nvmesh.js";
-      document.getElementById("reset").addEventListener("click", doReset);
-      var dropDrag = document.getElementById("dragMode");
-      dropDrag.onchange = function () {
-        switch (document.getElementById("dragMode").value) {
-          case "none":
-            nv1.opts.dragMode = nv1.dragModes.none;
-            break;
-          case "contrast":
-            nv1.opts.dragMode = nv1.dragModes.contrast;
-            break;
-          case "measurement":
-            nv1.opts.dragMode = nv1.dragModes.measurement;
-            break;
-          case "pan":
-            nv1.opts.dragMode = nv1.dragModes.pan;
-            break;
-          case "slicer3D":
-            nv1.opts.dragMode = nv1.dragModes.slicer3D;
-            break;
-        }
-      };
-      document
-        .getElementById("check1")
-        .addEventListener("change", doCheckClick);
-      function doCheckClick() {
-        nv1.setRadiologicalConvention(this.checked);
-      }
-      document
-        .getElementById("check2")
-        .addEventListener("change", doCheck2Click);
-      function doCheck2Click() {
-        nv1.opts.sagittalNoseLeft = this.checked;
-        nv1.drawScene();
-      }
-      document
-        .getElementById("check3")
-        .addEventListener("change", doCheck3Click);
-      function doCheck3Click() {
-        nv1.setSliceMM(this.checked);
-      }
-      var volumeList1 = [{ url: "../demos/images/pcasl.nii.gz" }];
-      function handleLocationChange(data) {
-        document.getElementById("location").innerHTML =
-          "&nbsp;&nbsp;" + data.string;
-      }
-      let defaults = {
-        loadingText: "there are no images",
-        backColor: [1, 1, 1, 1],
-        show3Dcrosshair: true,
-        logging: true,
-        limitFrames4D: 3,
-        displaySliceInfo: true,
-        displaySliceScale: 0.4,
-        enableBorderHighlight: true,
-        onLocationChange: handleLocationChange,
-      };
-      var nv1 = new Niivue(defaults);
-      nv1.setRadiologicalConvention(false);
-      nv1.attachTo("gl1");
-      nv1.setSliceType(nv1.sliceTypeMultiplanar);
-      nv1.opts.dragMode = nv1.dragModes.pan;
-      nv1.graph.autoSizeMultiplanar = true;
-      nv1.opts.multiplanarForceRender = true;
-      nv1.graph.normalizeValues = false;
-      nv1.graph.opacity = 1.0;
-      await nv1.loadVolumes(volumeList1);
-      await nv1.loadMeshes([{ url: "../demos/images/connectome.jcon" }]);
-      function doReset() {
-        nv1.setDefaults(defaults, true);
-      }
-    </script>
-  </body>
-</html>
+  document
+    .getElementById("drawOpacity")
+    .addEventListener("change", doDrawOpacity);
+  function doDrawOpacity() {
+    nv1.setDrawOpacity(this.value * 0.01);
+  }
+  document.getElementById("drawPen").addEventListener("change", doDrawPen);
+  function doDrawPen() {
+    const mode = parseInt(document.getElementById("drawPen").value);
+    nv1.setDrawingEnabled(mode >= 0);
+    if (mode >= 0) nv1.setPenValue(mode & 7, mode > 7);
+    if (mode === 12)
+      //erase selected cluster
+      nv1.setPenValue(-0);
+  }
+  document.getElementById("left").addEventListener("click", doLeft);
+  function doLeft() {
+    nv1.moveCrosshairInVox(-1, 0, 0);
+  }
+  document.getElementById("right").addEventListener("click", doRight);
+  function doRight() {
+    nv1.moveCrosshairInVox(1, 0, 0);
+  }
+  document.getElementById("posterior").addEventListener("click", doPosterior);
+  function doPosterior() {
+    nv1.moveCrosshairInVox(0, -1, 0);
+  }
+  document.getElementById("anterior").addEventListener("click", doAnterior);
+  function doAnterior() {
+    nv1.moveCrosshairInVox(0, 1, 0);
+  }
+  document.getElementById("inferior").addEventListener("click", doInferior);
+  function doInferior() {
+    nv1.moveCrosshairInVox(0, 0, -1);
+  }
+  document.getElementById("info").addEventListener("click", doInfo);
+  function doInfo() {
+    let obj = nv1.getDescriptives(0);
+    let str = JSON.stringify(obj, null, 2)
+    alert(str);
+  }
+  document.getElementById("superior").addEventListener("click", doSuperior);
+  function doSuperior() {
+    nv1.moveCrosshairInVox(0, 0, 1);
+  }
+  document.getElementById("undo").addEventListener("click", doUndo);
+  function doUndo() {
+    nv1.drawUndo();
+  }
+  document.getElementById("growcut").addEventListener("click", doGrowCut);
+  function doGrowCut() {
+    nv1.drawGrowCut();
+  }
+  document.getElementById("save").addEventListener("click", doSave);
+  function doSave() {
+    nv1.saveImage("test.nii", true);
+  }
+  document.getElementById("check1").addEventListener("change", doCheckClick);
+  function doCheckClick() {
+    nv1.drawFillOverwrites = this.checked;
+  }
+  document.getElementById("check2").addEventListener("change", doCheck2Click);
+  function doCheck2Click() {
+    nv1.setRadiologicalConvention(this.checked);
+  }
+  document.getElementById("check3").addEventListener("change", doCheck3Click);
+  function doCheck3Click() {
+    nv1.setSliceMM(this.checked);
+  }
+  document.getElementById("check9").addEventListener("change", doCheck9Click);
+  function doCheck9Click() {
+    nv1.setInterpolation(!this.checked);
+  }
+  document.getElementById("check10").addEventListener("change", doCheck10Click);
+  function doCheck10Click() {
+    nv1.setHighResolutionCapable(this.checked);
+  }
+
+  var volumeList1 = [{ url: "../demos/images/FLAIR.nii.gz" }];
+  var nv1 = new Niivue({
+    backColor: [1, 1, 1, 1],
+    enableBorderHighlight: true,
+  });
+  nv1.setRadiologicalConvention(false);
+  nv1.opts.multiplanarForceRender = true;
+  nv1.attachTo("gl1");
+  //nv1.opts.displaySliceInfo = true;
+  await nv1.loadVolumes(volumeList1);
+  nv1.setSliceType(nv1.sliceTypeMultiplanar);
+  await nv1.loadDrawingFromUrl("../demos/images/lesion.nii.gz");
+</script>

--- a/src/indexOK.html
+++ b/src/indexOK.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>NiiVue</title>
+    <link rel="stylesheet" href="niivue.css" />
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+  </head>
+  <body>
+    <noscript>
+      <strong>niivue requires JavaScript.</strong>
+    </noscript>
+    <header>
+      <label for="check1">LR</label>
+      <input type="checkbox" id="check1" unchecked />
+      <label for="check2">Nose</label>
+      <input type="checkbox" id="check2" unchecked />
+      <label for="check3">World</label>
+      <input type="checkbox" id="check3" unchecked />
+      <label for="dragMode">Drag mode</label>
+      <select id="dragMode">
+        <option value="contrast">contrast</option>
+        <option value="measurement">measurement</option>
+        <option value="pan" selected>pan/zoom</option>
+        <option value="slicer3D">slicer3D</option>
+        <option value="none">none</option>
+      </select>
+      <button id="reset">reset</button>
+    </header>
+    <main>
+      <canvas id="gl1"></canvas>
+    </main>
+    <footer id="location">&nbsp;</footer>
+    <script type="module" async>
+      import { Niivue } from "./niivue.js";
+      import { NVImage } from "./nvimage.js";
+      import { NVMesh } from "./nvmesh.js";
+      document.getElementById("reset").addEventListener("click", doReset);
+      var dropDrag = document.getElementById("dragMode");
+      dropDrag.onchange = function () {
+        switch (document.getElementById("dragMode").value) {
+          case "none":
+            nv1.opts.dragMode = nv1.dragModes.none;
+            break;
+          case "contrast":
+            nv1.opts.dragMode = nv1.dragModes.contrast;
+            break;
+          case "measurement":
+            nv1.opts.dragMode = nv1.dragModes.measurement;
+            break;
+          case "pan":
+            nv1.opts.dragMode = nv1.dragModes.pan;
+            break;
+          case "slicer3D":
+            nv1.opts.dragMode = nv1.dragModes.slicer3D;
+            break;
+        }
+      };
+      document
+        .getElementById("check1")
+        .addEventListener("change", doCheckClick);
+      function doCheckClick() {
+        nv1.setRadiologicalConvention(this.checked);
+      }
+      document
+        .getElementById("check2")
+        .addEventListener("change", doCheck2Click);
+      function doCheck2Click() {
+        nv1.opts.sagittalNoseLeft = this.checked;
+        nv1.drawScene();
+      }
+      document
+        .getElementById("check3")
+        .addEventListener("change", doCheck3Click);
+      function doCheck3Click() {
+        nv1.setSliceMM(this.checked);
+      }
+      var volumeList1 = [{ url: "../demos/images/pcasl.nii.gz" }];
+      function handleLocationChange(data) {
+        document.getElementById("location").innerHTML =
+          "&nbsp;&nbsp;" + data.string;
+      }
+      let defaults = {
+        loadingText: "there are no images",
+        backColor: [1, 1, 1, 1],
+        show3Dcrosshair: true,
+        logging: true,
+        limitFrames4D: 3,
+        displaySliceInfo: true,
+        displaySliceScale: 0.4,
+        enableBorderHighlight: true,
+        onLocationChange: handleLocationChange,
+      };
+      var nv1 = new Niivue(defaults);
+      nv1.setRadiologicalConvention(false);
+      nv1.attachTo("gl1");
+      nv1.setSliceType(nv1.sliceTypeMultiplanar);
+      nv1.opts.dragMode = nv1.dragModes.pan;
+      nv1.graph.autoSizeMultiplanar = true;
+      nv1.opts.multiplanarForceRender = true;
+      nv1.graph.normalizeValues = false;
+      nv1.graph.opacity = 1.0;
+      await nv1.loadVolumes(volumeList1);
+      await nv1.loadMeshes([{ url: "../demos/images/connectome.jcon" }]);
+      function doReset() {
+        nv1.setDefaults(defaults, true);
+      }
+    </script>
+  </body>
+</html>

--- a/src/niivue.js
+++ b/src/niivue.js
@@ -6390,7 +6390,8 @@ Niivue.prototype.drawHighlightBorder = function (leftTopWidthHeight) {
   const xEnd = left + width;
   const yStart = top;
   const yEnd = top + height;
-
+  this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
+  
   this.drawLine(
     [xStart, yStart, xEnd, yStart],
     this.opts.borderHighlightWidth,
@@ -7113,9 +7114,14 @@ Niivue.prototype.draw2D = function (
   }
   // draw highlight border if it is enabled in options as well as if current mosue pos is in a slice tile
   if (this.opts.enableBorderHighlight) {
-    const tile = this.inSliceTile(this.mousePos[0], this.mousePos[1]);
-    if (tile >= 0) {
-      this.drawHighlightBorder(this.screenSlices[tile].leftTopWidthHeight);
+    let mouseInTile = (
+      this.mousePos[0] > leftTopWidthHeight[0] &&
+      this.mousePos[1] > leftTopWidthHeight[1] &&
+      this.mousePos[0] < leftTopWidthHeight[0] + leftTopWidthHeight[2] &&
+      this.mousePos[1] < leftTopWidthHeight[1] + leftTopWidthHeight[3]
+    )
+    if (mouseInTile > 0) {
+      this.drawHighlightBorder(leftTopWidthHeight);
     }
   }
 


### PR DESCRIPTION
List of fixed issues (if they exist):

- Provides live demo so `npm run dev` showcases new features
- Fixes `enableBorderHighlight`. The prior code uses [`inSliceTile`](https://github.com/MelGGit/niivue/blob/fdb4a815deeedee3873e62084404410b75d8bb47/src/niivue.js#L7116) which returns tile number of mouse tile, meaning it can be redrawn many times as an array of tiles is being populated (e.g. if mouse is over tile 0, and there are a total of 3 tiles, the border gets redrawn 3 times).
- drawHighlightBorder() needs to set the correct (pixel based) viewport, in case the view port has been left as fractional image space.
